### PR TITLE
Batch data Echoing support.

### DIFF
--- a/datum/configs/tfr_configs.py
+++ b/datum/configs/tfr_configs.py
@@ -154,6 +154,12 @@ class DatasetConfigs(ConfigBase):
       docstring='Batch size for test data.',
       default_factory=lambda: 32,
   )
+  echoing = create_config(
+      name='echoing',
+      ty=int,
+      docstring='Batch echoing factor, if not None, echoes batches.',
+      default_factory=lambda: None,
+  )
   shuffle_files = create_config(
       name='shuffle_files',
       ty=bool,

--- a/datum/reader/dataset.py
+++ b/datum/reader/dataset.py
@@ -54,6 +54,7 @@ class Dataset():
             repeat: Optional[int] = None,
             bucket_fn: Optional[Callable[[tf.train.Example], int]] = None,
             shuffle: bool = False,
+            echoing: Optional[int] = None,
             full_dataset: bool = False,
             pre_batching_callback: Optional[Callable[[Dict], Dict]] = None,
             post_batching_callback: Optional[Callable[[Dict], Dict]] = None) -> DatasetType:
@@ -67,6 +68,7 @@ class Dataset():
       bucket_fn: element length computation fn for bucketing, for sporse inputs data can be
        batched based on element length.
       shuffle: whether to shuffle examples in the dataset.
+      echoing: batch echoing factor, if not None perform batch_echoing.
       full_dataset: if true, return the dataset as a single batch for dataset with single element.
       pre_batching_callback: data processing to apply before batching.
       post_batching_callback: data processing to apply post batching. This fucntion should support
@@ -101,6 +103,9 @@ class Dataset():
       dataset = dataset.apply(bucket_op)
     elif batch_size:
       dataset = dataset.padded_batch(batch_size, padded_shapes=self.padded_shapes)
+    if echoing:
+      dataset = dataset.flat_map(lambda example: tf.data.Dataset.from_tensors(example).repeat(echoing
+                                                                                              ))
     if repeat:
       logging.info(f'Dataset repeat is enabled for: {repeat} times.')
       dataset = dataset.repeat(count=repeat)
@@ -144,6 +149,7 @@ class Dataset():
         repeat=repeat,
         bucket_fn=self._dataset_configs.bucket_fn,
         shuffle=shuffle,
+        echoing=self._dataset_configs.echoing,
         full_dataset=self._dataset_configs.full_dataset,
         pre_batching_callback=self._dataset_configs.pre_batching_callback_train,
         post_batching_callback=self._dataset_configs.post_batching_callback_train)
@@ -166,6 +172,7 @@ class Dataset():
         repeat=repeat,
         bucket_fn=self._dataset_configs.bucket_fn,
         shuffle=shuffle,
+        echoing=None,
         full_dataset=self._dataset_configs.full_dataset,
         pre_batching_callback=self._dataset_configs.pre_batching_callback_val,
         post_batching_callback=self._dataset_configs.post_batching_callback_val)
@@ -188,6 +195,7 @@ class Dataset():
         repeat=repeat,
         bucket_fn=self._dataset_configs.bucket_fn,
         shuffle=shuffle,
+        echoing=None,
         full_dataset=self._dataset_configs.full_dataset,
         pre_batching_callback=self._dataset_configs.pre_batching_callback_test,
         post_batching_callback=self._dataset_configs.post_batching_callback_test)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -69,3 +69,21 @@ class TestDataset(absltest.TestCase):
     ds = self._dataset.train_fn('train', False)
     batch = next(iter(ds))
     self.assertEqual(batch['image'].shape, [2, 224, 224, 3])
+
+  def test_echoing(self):
+
+    def resize_image(example):
+      example['image'] = tf.image.resize(example['image'], [224, 224])
+      return example
+
+    dataset_configs = self._dataset.dataset_configs
+    dataset_configs.post_batching_callback_train = resize_image
+    dataset_configs.batch_size_train = 2
+    dataset_configs.echoing = 2
+    ds = iter(self._dataset.train_fn('train', False))
+    batch_1 = next(ds)
+    self.assertEqual(batch_1['image'].shape, [2, 224, 224, 3])
+    batch_2 = next(ds)
+    self.assertEqual(batch_2['image'].shape, [2, 224, 224, 3])
+    with self.assertRaises(StopIteration):
+      next(ds)


### PR DESCRIPTION
This PR adds support for Batch data echoing. Batch data echoing is important in the following scenarios:
- Computation bottleneck in the upstream processing 
- Low utilization of downstream accelerator. 
For more details visit: https://arxiv.org/pdf/1907.05550.pdf