### PR TITLE
Export API for TFRecord creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,29 @@ config = {
 cnf = AttrDict(config)
 ```
 
+### Create tfrecord dataset using export api
+```Python
+from datum.configs import TFRWriteConfigs
+from datum.export.export import export_to_tfrecord
+from datum.problem import types
+
+# set path to your input data
+input_path = "tests/dummy_data/cl"
+# set path to output data
+output_path = "output_tfrecord"
+
+write_configs = TFRWriteConfigs()
+write_configs.splits = {
+    "train": {
+        "num_examples": 2
+    },
+    "val": {
+        "num_examples": 2
+    },
+}
+export_to_tfrecord(input_path, output_path, types.IMAGE_CLF, write_configs)
+```
+
 
 ### Load tfrecord dataset as tf.data.Dataset
 Datset can be loaded as tf.data.Dataset as follows

--- a/datum/configs/default_configs.py
+++ b/datum/configs/default_configs.py
@@ -1,0 +1,62 @@
+# Copyright 2021 The OpenAGI Datum Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Default write configs for TFRecord export."""
+
+import os
+from functools import partial
+from pathlib import Path
+from typing import Optional
+
+from datum.configs import ConfigBase, TFRWriteConfigs
+from datum.encoder.encoder import datum_name_to_encoder
+from datum.problem import problem
+from datum.serializer.serializer import DatumSerializer
+from datum.utils.common_utils import AttrDict
+
+
+def get_default_write_configs(problem_type: str,
+                              label_names_file: Optional[str] = None) -> ConfigBase:
+  """Returns default write configs for a problem.
+
+  Args:
+    problem_type: Type of the problem,  any one from `datum.problems.types`.
+    label_names_file: Path to the label name file, required for `IMAGE_DET` problem.
+
+  Returns:
+    A `ConfigBase` config object.
+
+  Raises:
+    ValueError: If label_names_file is not valid, raised only for `IMAGE_DET` problem.
+  """
+  serializer = DatumSerializer(
+      problem.PROBLEM_PARAMS[problem_type]["serializer"],
+      datum_name_to_encoder_fn=datum_name_to_encoder)
+  if problem_type == problem.IMAGE_DET:
+    if not label_names_file:
+      raise ValueError("label_names_file must be provided for `IMAGE_DET` problem.")
+    if not Path(label_names_file).is_file():
+      raise ValueError(f"Input {label_names_file} does not exist or not a file.")
+
+    class_map = {
+        name: idx + 1
+        for idx, name in enumerate(open(os.path.join(label_names_file)).read().splitlines())
+    }
+    gen_config = AttrDict(has_test_annotations=True, class_map=class_map)
+  else:
+    gen_config = None
+  generator = partial(problem.PROBLEM_PARAMS[problem_type]["generator"], gen_config=gen_config)
+  write_configs = TFRWriteConfigs()
+  write_configs.serializer = serializer
+  write_configs.generator = generator
+  return write_configs

--- a/datum/configs/tfr_configs.py
+++ b/datum/configs/tfr_configs.py
@@ -28,11 +28,19 @@ class TFRWriteConfigs(ConfigBase):
   """
   generator = create_config(
       name='generator',
-      ty=Callable,
-      docstring='Generator class instance, ti should have a __call__ method.')
+      ty=object,
+      docstring='Generator class instance, it should have a __call__ method.')
+  serializer = create_config(
+      name='serializer',
+      ty=object,
+      docstring='Serializer class instance, it should have a __call__ method.')
   sparse_features = create_config(
       name='sparse_features', ty=list, docstring='A list of sparse features name in the dataset.')
-  splits = create_config(name='splits', ty=list, docstring='A list of split names in the dataset.')
+  splits = create_config(
+      name='splits',
+      ty=dict,
+      docstring='A dict of split names as keys and \
+      split attributes as values in the dataset.')
   num_train_examples = create_config(
       name='num_train_examples', ty=int, docstring='Num of train examples in the dataset.')
   num_val_examples = create_config(

--- a/datum/export/export.py
+++ b/datum/export/export.py
@@ -1,0 +1,85 @@
+# Copyright 2021 The OpenAGI Datum Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from pathlib import Path
+
+from absl import logging
+
+from datum.configs import ConfigBase
+from datum.configs.default_configs import get_default_write_configs
+from datum.problem import types
+from datum.writer.tfrecord_writer import TFRecordWriter
+
+
+def export_to_tfrecord(input_path: str, output_path: str, problem_type: str,
+                       write_configs: ConfigBase) -> None:
+  """Export data to tfrecord format.
+
+  Args:
+    input_path: Root path to input data folder.
+    output_path: Path to store output tfrecords and generated metadata.
+    problem_type: Type of the problem, see `datum.probelm.types` for available problems.
+
+    write_configs has the following configurable attributes:
+      generator: Generator class.
+      serializer: Serializer instance.
+      splits: A dict with split names as keys and split attributes as values.
+        Following split attributes are supported:
+          num_examples: Number of examples in the split.
+          extension: Input image extension in case of image data, all input should have same
+            extension.
+            default: For image data, `.jpg`
+          image_dir: Name of the directory containing the data, used for image classification.
+            default: split name, eg: train for classification, for detection `JPEGImages` -a s per
+              VOC12 folder structure.
+          csv_path: Path to ground truths csv file, used for classification dataset.
+            default: split name with .csv extension, eg: train.csv
+          set_dir: In case of VOC12 style  datasets, image set information.
+            default: `ImageSets` as per VOC12 dataset folder structure
+          annotation_dir: Directory with annotations, used for VOC12 style datasets.
+            default: `Annotations` as per VOC12 dataset folder structure
+          label_dir: Directory with label images, used in segmentation.
+            default: `SegmentationClass` for as per VOC12 folder structure.
+          image_extension: Extension of input images, used in segmentation.
+            default: `.jpg`
+          label_extension: Extension of label images, used in segmentation.
+            default: `.png`
+
+    Raises:
+      ValueError: If splits information is not in the dict format.
+  """
+  label_names_file = None
+  if problem_type == types.IMAGE_DET:
+    label_names_file = os.path.join(input_path, "classes.names")
+  base_write_configs = get_default_write_configs(problem_type, label_names_file)
+  write_configs = base_write_configs.merge(write_configs)
+  splits = write_configs.splits
+  if not isinstance(splits, dict):
+    raise ValueError(f"Splits must be a dict in the input config: {write_configs}")
+  generator = write_configs.generator(input_path)
+  Path(output_path).mkdir(parents=True, exist_ok=True)
+  for split, split_kwargs in splits.items():
+    logging.info(f'Creating tfrecord writer for split: {split}.')
+    tfr_writer = TFRecordWriter(
+        generator,
+        write_configs.serializer,
+        output_path,
+        split,
+        split_kwargs["num_examples"],
+        sparse_features=write_configs.sparse_features,
+        **split_kwargs)
+    logging.info('Starting conversion process.')
+    tfr_writer.create_records()
+    logging.info(f'Completed tfrecord conversion for input split: {split}')

--- a/datum/problem/problem.py
+++ b/datum/problem/problem.py
@@ -1,0 +1,37 @@
+# Copyright 2021 The OpenAGI Datum Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Problems default parameters."""
+
+from datum.generator.image import (ClfDatumGenerator, DetDatumGenerator, SegDatumGenerator)
+from datum.generator.text import TextJsonDatumGenerator
+from datum.problem.types import IMAGE_CLF, IMAGE_DET, IMAGE_SEG, TEXT_CLF
+
+PROBLEM_PARAMS = {
+    IMAGE_CLF: {
+        "serializer": "image",
+        "generator": ClfDatumGenerator,
+    },
+    IMAGE_DET: {
+        "serializer": "image",
+        "generator": DetDatumGenerator,
+    },
+    IMAGE_SEG: {
+        "serializer": "image",
+        "generator": SegDatumGenerator,
+    },
+    TEXT_CLF: {
+        "serializer": "text",
+        "generator": TextJsonDatumGenerator,
+    },
+}

--- a/datum/problem/types.py
+++ b/datum/problem/types.py
@@ -1,0 +1,19 @@
+# Copyright 2021 The OpenAGI Datum Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Datum default problem types."""
+
+IMAGE_CLF = "image_clf"
+IMAGE_DET = "image_det"
+IMAGE_SEG = "image_seg"
+TEXT_CLF = "text_clf"

--- a/datum/reader/loader.py
+++ b/datum/reader/loader.py
@@ -31,7 +31,7 @@ def load(path: str, dataset_configs: Optional[ConfigBase] = None) -> DatasetType
       the output tf.data.Dataset. This is designed to give an extensive control of
       the dataset pre and post processsing operation to the end-user.
 
-    dataset_confugs has the following configurable attributes.
+    dataset_configs has the following configurable attributes.
       buffer_size: Representing the number of elements from this dataset from which the
            new dataset will sample, default: 100.
       seed: Random seed for tfrecord files based randomness, default: 6052020.

--- a/datum/version.py
+++ b/datum/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '1.0.1'
+__version__ = '1.1.0'

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The OpenAGI Datum Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import tensorflow as tf
 
 from datum.configs import config_base

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The OpenAGI Datum Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import tempfile
 from shutil import rmtree
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,30 @@
+import os
+import tempfile
+
+import pytest
+
+from datum.configs import TFRWriteConfigs
+from datum.export import export
+from datum.problem import types
+
+
+@pytest.mark.parametrize("problem_type,input_data", [(types.IMAGE_CLF, "tests/dummy_data/clf"),
+                                                     (types.IMAGE_DET, "tests/dummy_data/det/voc"),
+                                                     (types.IMAGE_SEG, "tests/dummy_data/seg/voc")])
+def test_export_to_tfrecord(problem_type, input_data):
+  with tempfile.TemporaryDirectory() as tempdir:
+    write_configs = TFRWriteConfigs()
+    write_configs.splits = {
+        "train": {
+            "num_examples": 1
+        },
+        "val": {
+            "num_examples": 1
+        },
+    }
+    export.export_to_tfrecord(input_data, tempdir, problem_type, write_configs)
+    files = os.listdir(tempdir)
+    assert [
+        'val-00000-of-00001.tfrecord', 'train-00000-of-00001.tfrecord', 'shard_info.json',
+        'datum_to_type_and_shape_mapping.json'
+    ] == files

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The OpenAGI Datum Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import os
 import tempfile
 
@@ -8,9 +21,14 @@ from datum.export import export
 from datum.problem import types
 
 
-@pytest.mark.parametrize("problem_type,input_data", [(types.IMAGE_CLF, "tests/dummy_data/clf"),
-                                                     (types.IMAGE_DET, "tests/dummy_data/det/voc"),
-                                                     (types.IMAGE_SEG, "tests/dummy_data/seg/voc")])
+@pytest.mark.parametrize(
+    "problem_type,input_data",
+    [
+        (types.IMAGE_CLF, "tests/dummy_data/clf"),
+        (types.IMAGE_DET, "tests/dummy_data/det/voc"),
+        (types.IMAGE_SEG, "tests/dummy_data/seg/voc"),
+    ],
+)
 def test_export_to_tfrecord(problem_type, input_data):
   with tempfile.TemporaryDirectory() as tempdir:
     write_configs = TFRWriteConfigs()
@@ -23,8 +41,10 @@ def test_export_to_tfrecord(problem_type, input_data):
         },
     }
     export.export_to_tfrecord(input_data, tempdir, problem_type, write_configs)
-    files = os.listdir(tempdir)
+    files = sorted(os.listdir(tempdir))
     assert [
-        'val-00000-of-00001.tfrecord', 'train-00000-of-00001.tfrecord', 'shard_info.json',
-        'datum_to_type_and_shape_mapping.json'
+        "datum_to_type_and_shape_mapping.json",
+        "shard_info.json",
+        "train-00000-of-00001.tfrecord",
+        "val-00000-of-00001.tfrecord",
     ] == files

--- a/tests/test_generator_image.py
+++ b/tests/test_generator_image.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The OpenAGI Datum Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import os
 
 from absl.testing import absltest

--- a/tests/test_generator_text.py
+++ b/tests/test_generator_text.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The OpenAGI Datum Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import json
 import os
 import tempfile

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The OpenAGI Datum Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import tempfile
 from shutil import rmtree
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The OpenAGI Datum Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import os
 from pathlib import Path
 from shutil import rmtree

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The OpenAGI Datum Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import numpy as np
 import tensorflow as tf
 from absl.testing import absltest

--- a/tests/test_tfr_reader.py
+++ b/tests/test_tfr_reader.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The OpenAGI Datum Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import tempfile
 from shutil import rmtree
 

--- a/tests/test_tfrecord_writer.py
+++ b/tests/test_tfrecord_writer.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The OpenAGI Datum Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import os
 import tempfile
 from pathlib import Path

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The OpenAGI Datum Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import json
 import os
 import tempfile


### PR DESCRIPTION
Add export interface for creating tfrecord files easily. This reduces the need of writing and initializing various components for creating tfrecords files. 