### PR TITLE
Disable default padding of batch elements. 

### DIFF
--- a/datum/configs/tfr_configs.py
+++ b/datum/configs/tfr_configs.py
@@ -305,3 +305,15 @@ class DatasetConfigs(ConfigBase):
         tfrecord files to construct a tf.data.Dataset.',
       default_factory=TFRReadConfigs,
   )
+  use_tf_padding = create_config(
+      name='use_tf_padding',
+      ty=bool,
+      docstring="If set True, uses Tensorflow interpreted shapes for padding.",
+      default_factory=lambda: False,
+  )
+  use_datum_padding = create_config(
+      name='use_datum_padding',
+      ty=bool,
+      docstring="If set True, uses Datum interpreted shapes for padding.",
+      default_factory=lambda: False,
+  )

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -57,6 +57,7 @@ class TestDataset(absltest.TestCase):
 
     dataset_configs = self._dataset.dataset_configs
     dataset_configs.pre_batching_callback_train = resize_image
+    dataset_configs.use_datum_padding = True
     self._dataset.daatset_configs = dataset_configs
     ds = self._dataset.train_fn('train', False)
     batch = next(iter(ds))
@@ -78,6 +79,7 @@ class TestDataset(absltest.TestCase):
     dataset_configs = self._dataset.dataset_configs
     dataset_configs.post_batching_callback_train = resize_image
     dataset_configs.batch_size_train = 2
+    dataset_configs.use_datum_padding = True
     self._dataset.daatset_configs = dataset_configs
     ds = self._dataset.train_fn('train', False)
     batch = next(iter(ds))
@@ -93,6 +95,7 @@ class TestDataset(absltest.TestCase):
     dataset_configs.post_batching_callback_train = resize_image
     dataset_configs.batch_size_train = 2
     dataset_configs.echoing = 2
+    dataset_configs.use_datum_padding = True
     ds = iter(self._dataset.train_fn('train', False))
     batch_1 = next(ds)
     self.assertEqual(batch_1['image'].shape, [2, 224, 224, 3])


### PR DESCRIPTION
This PR disables the default padding of batch elements to match shapes within a batch. 
To enable padding of elements using datum interpreted shape use `dataset_configs.use_dautm_padding=True`. 