### PR TITLE
Update tensorflow support to 2.16

### DIFF
--- a/.github/workflows/datum_py310.yml
+++ b/.github/workflows/datum_py310.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v1
       with:
-        python-version: 3.10.13
+        python-version: 3.10.14
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/datum/version.py
+++ b/datum/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '1.9.0'
+__version__ = '1.11.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # core lib dep
-tensorflow <=2.17
+tensorflow <2.17
 opencv-python==4.5.*
 absl-py>=0.10
 tqdm>=4.39.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # core lib dep
-tensorflow <=2.15
+tensorflow <=2.17
 opencv-python==4.5.*
 absl-py>=0.10
 tqdm>=4.39.0


### PR DESCRIPTION
This PR adds support for TensorFlow 2.16. This version uses new Keras APIs.