### PR TITLE
Make jpeg encoding more accurate

### DIFF
--- a/datum/reader/parser.py
+++ b/datum/reader/parser.py
@@ -112,9 +112,9 @@ class DatumParser():
       dtype = self.pytype_to_tftype[self.datum_to_type_shape[key]['type']]
       if dtype == tf.string:
         if len(self.datum_to_type_shape[key]['shape']) == 2:
-          deserialized_outputs[key] = tf.io.decode_jpeg(value, 1)
+          deserialized_outputs[key] = tf.io.decode_jpeg(value, 1, dct_method="INTEGER_ACCURATE")
         elif len(self.datum_to_type_shape[key]['shape']) == 3:
-          deserialized_outputs[key] = tf.io.decode_jpeg(value, 3)
+          deserialized_outputs[key] = tf.io.decode_jpeg(value, 3, dct_method="INTEGER_ACCURATE")
         elif self.datum_to_type_shape[key]['dense']:
           deserialized_outputs[key] = value
         else:

--- a/datum/version.py
+++ b/datum/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '1.11.0'
+__version__ = '1.11.1'


### PR DESCRIPTION
Use `dct_method="INTEGER_ACCURATE"` for getting PIL equivalent JPEG result.